### PR TITLE
HIPCMS-499 Fix broken link in invite users email

### DIFF
--- a/src/Api/Utility/invation-email.html
+++ b/src/Api/Utility/invation-email.html
@@ -1,11 +1,14 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8" />
-    <title></title>
+  <meta charset="utf-8" />
+  <title></title>
 </head>
 <body>
-    <p>Du wurdest eingeladen dich in der History in Paderborn App zu registrieren.</p>
-    <p>Nutze bitte diesen <a href="http://docker-hip.cs.upb.de/signup/?email={email}">Link um dich zu registrieren</a></p>
+  <p>Liebe Studierende, lieber Studierender,</p>
+  <p>du wurdest eingeladen, dich für das Content Management System der History in Paderborn App zu registrieren.</p>
+  <p>Bitte besuche die <a href="http://docker-hip.cs.upb.de/signup?email={email}">Registrierungsseite</a>, um deinen Account zu erstellen und ein Passwort zu vergeben.</p>
+  <p>Mit freundlichen Grüßen</p>
+  <p>Das Team der History in Paderborn App</p>
 </body>
 </html>


### PR DESCRIPTION
There's a / too much in the URL for the signup page.