### PR TITLE
Iss hipcms 504 invite users

### DIFF
--- a/src/Api/Controllers/UsersController.cs
+++ b/src/Api/Controllers/UsersController.cs
@@ -39,10 +39,11 @@ namespace Api.Controllers
         /// <response code="503">Service unavailable</response>        
         /// <response code="401">User is denied</response>
         [HttpPost("Invite")]
-        [ProducesResponseType(typeof(void), 202)]
+        [ProducesResponseType(typeof(UserManager.InvitationResult), 202)]
         [ProducesResponseType(typeof(void), 400)]
+        [ProducesResponseType(typeof(void), 401)]
         [ProducesResponseType(typeof(void), 403)]
-        [ProducesResponseType(typeof(void), 409)]
+        [ProducesResponseType(typeof(UserManager.InvitationResult), 409)]
         [ProducesResponseType(typeof(void), 503)]
         public IActionResult InviteUsers([FromBody]InviteFormModel model, [FromServices]IEmailSender emailSender)
         {
@@ -51,12 +52,10 @@ namespace Api.Controllers
 
             if (ModelState.IsValid)
             {
-                Tuple<List<String>, List<String>> result = userManager.InviteUsers(model.emails, emailSender);
-                List<String> failedInvitations = result.Item1;
-                List<String> existingUsers = result.Item2;
-                if (failedInvitations.Count == model.emails.Length)
+                UserManager.InvitationResult result = userManager.InviteUsers(model.emails, emailSender);
+                if (result.failedInvitations.Count == model.emails.Length)
                     return BadRequest(result);
-                if (existingUsers.Count == model.emails.Length)
+                if (result.existingUsers.Count == model.emails.Length)
                     return StatusCode(409, result);
 
                 return Accepted(result);

--- a/src/Api/Controllers/UsersController.cs
+++ b/src/Api/Controllers/UsersController.cs
@@ -44,14 +44,14 @@ namespace Api.Controllers
         [ProducesResponseType(typeof(void), 403)]
         [ProducesResponseType(typeof(void), 409)]
         [ProducesResponseType(typeof(void), 503)]
-        public IActionResult InviteUsers(InviteFormModel model)
+        public IActionResult InviteUsers([FromBody]InviteFormModel model, [FromServices]IEmailSender emailSender)
         {
             if (!userPermissions.IsAllowedToInvite(User.Identity.GetUserId()))
                 return Forbidden();
 
             if (ModelState.IsValid)
             {
-                Tuple<List<String>, List<String>> result = userManager.InviteUsers(model.emails);
+                Tuple<List<String>, List<String>> result = userManager.InviteUsers(model.emails, emailSender);
                 List<String> failedInvitations = result.Item1;
                 List<String> existingUsers = result.Item2;
                 if (failedInvitations.Count == model.emails.Length)

--- a/src/Api/Managers/UserManager.cs
+++ b/src/Api/Managers/UserManager.cs
@@ -13,10 +13,7 @@ namespace Api.Managers
     {
         private EmailSender emailSender;
 
-        public UserManager(CmsDbContext dbContext) : base(dbContext)
-        {
-            this.emailSender = (EmailSender)Startup.ServiceProvider.GetService(typeof(EmailSender)); ;
-        }
+        public UserManager(CmsDbContext dbContext) : base(dbContext) { }
 
         public virtual IEnumerable<UserResult> GetAllUsers(string query, string role, int page, int pageSize)
         {
@@ -121,6 +118,15 @@ namespace Api.Managers
             return false;
         }
 
+        private void LoadEmailSender()
+        {
+            // dirty hack to get the injected IEmailSender service
+            if (this.emailSender == null)
+            {
+                this.emailSender = (EmailSender)Startup.ServiceProvider.GetService(typeof(EmailSender));
+            }
+        }
+
         /// <summary>
         /// Invite the users identified by the given email addresses.
         /// This also creates users in the database.
@@ -131,6 +137,7 @@ namespace Api.Managers
         /// <returns>Tuple containing (1) the failed invitations and (2) existing users lists.</returns>
         public Tuple<List<String>, List<String>> InviteUsers(string[] emails)
         {
+            LoadEmailSender();
             List<String> failedInvitations = new List<string>();
             List<String> existingUsers = new List<string>();
             foreach (string email in emails)

--- a/src/Api/Managers/UserManager.cs
+++ b/src/Api/Managers/UserManager.cs
@@ -11,8 +11,6 @@ namespace Api.Managers
 {
     public class UserManager : BaseManager
     {
-        private EmailSender emailSender;
-
         public UserManager(CmsDbContext dbContext) : base(dbContext) { }
 
         public virtual IEnumerable<UserResult> GetAllUsers(string query, string role, int page, int pageSize)
@@ -118,15 +116,6 @@ namespace Api.Managers
             return false;
         }
 
-        private void LoadEmailSender()
-        {
-            // dirty hack to get the injected IEmailSender service
-            if (this.emailSender == null)
-            {
-                this.emailSender = (EmailSender)Startup.ServiceProvider.GetService(typeof(EmailSender));
-            }
-        }
-
         /// <summary>
         /// Invite the users identified by the given email addresses.
         /// This also creates users in the database.
@@ -135,9 +124,8 @@ namespace Api.Managers
         /// </summary>
         /// <param name="emails">A string array of email addresses</param>
         /// <returns>Tuple containing (1) the failed invitations and (2) existing users lists.</returns>
-        public Tuple<List<String>, List<String>> InviteUsers(string[] emails)
+        public Tuple<List<String>, List<String>> InviteUsers(string[] emails, IEmailSender emailSender)
         {
-            LoadEmailSender();
             List<String> failedInvitations = new List<string>();
             List<String> existingUsers = new List<string>();
             foreach (string email in emails)

--- a/src/Api/Managers/UserManager.cs
+++ b/src/Api/Managers/UserManager.cs
@@ -116,6 +116,12 @@ namespace Api.Managers
             return false;
         }
 
+        public struct InvitationResult
+        {
+            public List<String> failedInvitations;
+            public List<String> existingUsers;
+        }
+
         /// <summary>
         /// Invite the users identified by the given email addresses.
         /// This also creates users in the database.
@@ -124,7 +130,7 @@ namespace Api.Managers
         /// </summary>
         /// <param name="emails">A string array of email addresses</param>
         /// <returns>Tuple containing (1) the failed invitations and (2) existing users lists.</returns>
-        public Tuple<List<String>, List<String>> InviteUsers(string[] emails, IEmailSender emailSender)
+        public InvitationResult InviteUsers(string[] emails, IEmailSender emailSender)
         {
             List<String> failedInvitations = new List<string>();
             List<String> existingUsers = new List<string>();
@@ -153,8 +159,7 @@ namespace Api.Managers
                     failedInvitations.Add(email);
                 }
             }
-   
-            return Tuple.Create(failedInvitations, existingUsers);
+            return new InvitationResult() { failedInvitations = failedInvitations, existingUsers = existingUsers };
         }
 
     }


### PR DESCRIPTION
* returns all users that already existed in `res.existingUsers` array
  * returns a 409 if all given users already exist in the database
* returns all users for which sending the email failed (which is probably because the mail server is not configured properly) in `res.failedInvitations` array
  * returns a 400 if sending the email fails for all given users
* if some or all invitations succeed, a code 202 is returned